### PR TITLE
Rework nix flake

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ node_modules/
 
 *.local.*
 *.local
+
+result

--- a/flake.lock
+++ b/flake.lock
@@ -1,5 +1,23 @@
 {
   "nodes": {
+    "flake-parts": {
+      "inputs": {
+        "nixpkgs-lib": "nixpkgs-lib"
+      },
+      "locked": {
+        "lastModified": 1717285511,
+        "narHash": "sha256-iKzJcpdXih14qYVcZ9QC9XuZYnPc6T8YImb6dX166kw=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "2a55567fcf15b1b1c7ed712a2c6fadaec7412ea8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1717608337,
@@ -16,8 +34,21 @@
         "type": "github"
       }
     },
+    "nixpkgs-lib": {
+      "locked": {
+        "lastModified": 1717284937,
+        "narHash": "sha256-lIbdfCsf8LMFloheeE6N31+BMIeixqyQWbSr2vk79EQ=",
+        "type": "tarball",
+        "url": "https://github.com/NixOS/nixpkgs/archive/eb9ceca17df2ea50a250b6b27f7bf6ab0186f198.tar.gz"
+      },
+      "original": {
+        "type": "tarball",
+        "url": "https://github.com/NixOS/nixpkgs/archive/eb9ceca17df2ea50a250b6b27f7bf6ab0186f198.tar.gz"
+      }
+    },
     "root": {
       "inputs": {
+        "flake-parts": "flake-parts",
         "nixpkgs": "nixpkgs"
       }
     }

--- a/flake.lock
+++ b/flake.lock
@@ -2,16 +2,16 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1715691446,
-        "narHash": "sha256-4UUvzMzEKkyhmj+iu5wD4RiZz6hjOJyqbHea3y3HyKs=",
+        "lastModified": 1717608337,
+        "narHash": "sha256-pliB8KPAkNe6WIB6LbS5xoiLKgIXg6pUWu8KASiB3JI=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "6c7da9d305628d92202eb475048129cb86a89e9d",
+        "rev": "b5130b8f49de96019b4506a49e689b8e97df5249",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "release-23.11",
+        "ref": "release-24.05",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -2,27 +2,35 @@
   description = "cfn-changeset-viewer";
 
   inputs = {
+    flake-parts.url = "github:hercules-ci/flake-parts";
     nixpkgs.url = "github:NixOS/nixpkgs/release-24.05";
   };
-  outputs = { nixpkgs, ... }:
-    let
-      shell = { system }:
+  outputs =
+    inputs@{ self, flake-parts, ... }:
+    flake-parts.lib.mkFlake { inherit inputs; } {
+      perSystem =
+        { self', pkgs, ... }:
         let
-          pkgs = import nixpkgs {
-            system = system;
-          };
+          buildNpmPackage = pkgs.buildNpmPackage.override { nodejs = pkgs.nodejs_20; };
         in
-        pkgs.mkShell {
-          buildInputs = [
-            pkgs.awscli2
-            pkgs.nodejs_20
-          ];
+        {
+          packages = {
+            cfn-changeset-viewer = buildNpmPackage {
+              pname = "cfn-changeset-viewer";
+              version = toString (self.shortRev or self.dirtyShortRev or self.lastModified or "unknown");
+              src = ./.;
+              npmDepsHash = "sha256-ICaGtofENMaAjk/KGRn8RgpMAICSttx4AIcbi1HsW8Q=";
+              dontNpmBuild = true;
+              meta.mainProgram = "cfn-changeset-viewer";
+            };
+            default = self'.packages.cfn-changeset-viewer;
+          };
+
+          devShells.default = pkgs.mkShell {
+            packages = [ pkgs.awscli2 ];
+            inputsFrom = [ self'.packages.default ];
+          };
         };
-    in
-    {
-      devShells.aarch64-darwin.default = shell { system = "aarch64-darwin"; };
-      devShells.x86_64-darwin.default = shell { system = "x86_64-darwin"; };
-      devShells.aarch64-linux.default = shell { system = "aarch64-linux"; };
-      devShells.x86_64-linux.default = shell { system = "x86_64-linux"; };
+      systems = inputs.nixpkgs.lib.systems.flakeExposed;
     };
 }

--- a/flake.nix
+++ b/flake.nix
@@ -2,7 +2,7 @@
   description = "cfn-changeset-viewer";
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs/release-23.11";
+    nixpkgs.url = "github:NixOS/nixpkgs/release-24.05";
   };
   outputs = { nixpkgs, ... }:
     let


### PR DESCRIPTION
- nixpkgs 23.11 is now deprecated so updated the flake to 24.05
- made the flake use [flake-parts](https://github.com/hercules-ci/flake-parts) as it makes handling other archs/systems easier
- flake now exposes package so it's now possible to run eg. `nix run github:trek10inc/cfn-changeset-viewer#cfn-changeset-viewer -L -- --change-set-name blabla` or straight up add it to ur NixOS/home-manager/nix-darwin config

for now drafting as I'm on my personal pc, i'll test it fully tomorrow @ work and i'll let u know
also, not sure if it works on macos so please check as i can't.

i'll submit it later to nixpkgs too