### PR TITLE
Add --region CLI option

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -10,6 +10,7 @@ Options:
   --version                    Show version number [boolean]
   --change-set-name            The name or ARN of the change set [string] [required]
   --stack-name                 The name of the stack, only required if the change set ARN is not specified [string]
+  --region                     The AWS region where the change-set is located [string]
   --show-unchanged-properties  Show unchanged properties in the diff [boolean]
   --help                       Show help [boolean]
 Usage:


### PR DESCRIPTION
### Thanks

Thanks for creating this convenient tool. It's much more pleasant to review change-sets now.

### The Change

Just a small quality-of-life feature.

This PR adds a `--region` option to the CLI, for configuring the cloudformation client directly with an AWS region, instead of relying on environment variables, which is just a little bit more cumbersome in my experience.

I only had to move the cfn const from global to local, which for this simple architecture doesn't affect much.

### Disclaimer

I'm not a js engineer, so my apologies if there's something I missed while preparing this PR.